### PR TITLE
Add configuration app for Twitch to Minecraft event bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,53 @@
-# Vibe-Coding-Stream
+# Vibe Coding Stream Event Bridge
+
+Dieses Projekt stellt die Grundstruktur für eine Web-Anwendung bereit, mit der Twitch-Chat-Befehle auf Aktionen eines dedizierten Minecraft-Servers gemappt werden können. Die Anwendung konzentriert sich auf die Konfigurationsoberfläche und speichert alle Schnittstelleninformationen zentral in einer JSON-Datei.
+
+## Überblick
+
+- **Twitch Schnittstelle**: Konfiguriere Benutzername, Client-Informationen und OAuth-Token des gewünschten Twitch-Kontos. Über die API-Endpunkte kann später ein Chat-Listener implementiert werden, der Befehle von Zuschauer:innen entgegennimmt.
+- **Minecraft Schnittstelle**: Hinterlege Host, RCON-Port, Passwort und einen Basis-Pfad für Skripte, die auf dem dedizierten Server liegen. Die Konfiguration bildet die Grundlage für spätere Trigger, die Minecraft-Ereignisse auslösen.
+- **Command Mapping**: Ordne Klartext-Chatbefehle konkreten Skriptnamen zu. Diese Mappings werden genutzt, um aus Twitch-Nachrichten auslösbare Events zu erzeugen.
+
+## Projektstruktur
+
+```
+├── config/
+│   └── settings.json          # Persistente Konfiguration für Twitch, Minecraft und Befehls-Mappings
+├── public/
+│   ├── index.html             # Web UI zur Pflege der Konfiguration
+│   ├── main.js                # Frontend-Logik für das Speichern/Laden der Konfiguration
+│   └── styles.css             # Oberflächen-Styling
+└── src/
+    ├── server.js              # HTTP-Server mit REST-API für die Konfiguration
+    └── eventBridge.js         # EventBridge-Klasse als Startpunkt für die spätere Integration
+```
+
+## Nutzung
+
+1. **Abhängigkeiten installieren**: Das Projekt kommt ohne externe Pakete aus und nutzt ausschließlich Node.js Kernmodule, damit es auch in eingeschränkten Umgebungen läuft.
+2. **Server starten**:
+
+   ```bash
+   node src/server.js
+   ```
+
+3. **Web-Oberfläche öffnen**: Rufe im Browser `http://localhost:3000` auf. Dort können die Schnittstelleninformationen gepflegt und neue Mappings angelegt werden.
+
+## API-Überblick
+
+| Methode | Pfad                          | Beschreibung                                  |
+| ------- | ----------------------------- | --------------------------------------------- |
+| GET     | `/api/config`                 | Liefert die komplette Konfiguration           |
+| POST    | `/api/config/twitch`          | Aktualisiert die Twitch-spezifischen Werte    |
+| POST    | `/api/config/minecraft`       | Aktualisiert die Minecraft-spezifischen Werte |
+| POST    | `/api/config/commands`        | Fügt ein neues Mapping hinzu oder aktualisiert es |
+| DELETE  | `/api/config/commands/:cmd`   | Entfernt ein bestehendes Mapping              |
+
+Die gespeicherte Konfiguration kann von Listener-Services (z. B. Twitch Chat Bot, Minecraft Remote Control) eingelesen werden, um den Eventfluss aufzubauen.
+
+## Weiteres Vorgehen
+
+- Implementierung eines Twitch Chat Listeners (z. B. über die IRC-Schnittstelle), der `EventBridge#createTwitchEventPayload` nutzt.
+- Aufbau eines Minecraft-RCON-Clients, der Trigger aus `EventBridge#createMinecraftTrigger` verarbeitet.
+- Erweiterung der Web-Oberfläche um Validierung, Authentifizierung und Rollenkonzepte, sobald mehrere Personen auf die Konfiguration zugreifen sollen.
+

--- a/config/settings.json
+++ b/config/settings.json
@@ -1,0 +1,16 @@
+{
+  "twitch": {
+    "username": "",
+    "clientId": "",
+    "clientSecret": "",
+    "oauthToken": "",
+    "channel": ""
+  },
+  "minecraft": {
+    "host": "",
+    "rconPort": 25575,
+    "rconPassword": "",
+    "scriptBasePath": ""
+  },
+  "commandMappings": []
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "vibe-coding-stream",
+  "version": "1.0.0",
+  "description": "Web-Konfiguration für Twitch-Minecraft Event Bridge",
+  "main": "src/server.js",
+  "scripts": {
+    "start": "node src/server.js"
+  },
+  "keywords": [
+    "twitch",
+    "minecraft",
+    "event",
+    "configuration"
+  ],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,107 @@
+<!DOCTYPE html>
+<html lang="de">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Event Bridge Konfiguration</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <main class="container">
+      <h1>Event Bridge Konfiguration</h1>
+      <section>
+        <h2>Twitch Schnittstelle</h2>
+        <form id="twitch-form">
+          <div class="form-row">
+            <label for="twitch-username">Benutzername</label>
+            <input id="twitch-username" name="username" required />
+          </div>
+          <div class="form-row">
+            <label for="twitch-clientId">Client ID</label>
+            <input id="twitch-clientId" name="clientId" />
+          </div>
+          <div class="form-row">
+            <label for="twitch-clientSecret">Client Secret</label>
+            <input id="twitch-clientSecret" name="clientSecret" type="password" />
+          </div>
+          <div class="form-row">
+            <label for="twitch-token">OAuth Token</label>
+            <input id="twitch-token" name="oauthToken" type="password" />
+          </div>
+          <div class="form-row">
+            <label for="twitch-channel">Channel</label>
+            <input id="twitch-channel" name="channel" />
+          </div>
+          <button type="submit">Speichern</button>
+        </form>
+      </section>
+
+      <section>
+        <h2>Minecraft Schnittstelle</h2>
+        <form id="minecraft-form">
+          <div class="form-row">
+            <label for="minecraft-host">Host</label>
+            <input id="minecraft-host" name="host" />
+          </div>
+          <div class="form-row">
+            <label for="minecraft-port">RCON Port</label>
+            <input id="minecraft-port" name="rconPort" type="number" min="1" max="65535" />
+          </div>
+          <div class="form-row">
+            <label for="minecraft-password">RCON Passwort</label>
+            <input id="minecraft-password" name="rconPassword" type="password" />
+          </div>
+          <div class="form-row">
+            <label for="minecraft-scriptBasePath">Script Basis Pfad</label>
+            <input id="minecraft-scriptBasePath" name="scriptBasePath" />
+          </div>
+          <button type="submit">Speichern</button>
+        </form>
+      </section>
+
+      <section>
+        <h2>Command Mapping</h2>
+        <form id="command-form">
+          <div class="form-row">
+            <label for="command-command">Chat Befehl</label>
+            <input id="command-command" name="command" placeholder="z.B. !start" required />
+          </div>
+          <div class="form-row">
+            <label for="command-script">Script Name</label>
+            <input id="command-script" name="scriptName" placeholder="z.B. start_event.sh" required />
+          </div>
+          <div class="form-row">
+            <label for="command-description">Beschreibung</label>
+            <input id="command-description" name="description" placeholder="Optionale Beschreibung" />
+          </div>
+          <button type="submit">Hinzufügen / Aktualisieren</button>
+        </form>
+        <table id="command-table">
+          <thead>
+            <tr>
+              <th>Chat Befehl</th>
+              <th>Script</th>
+              <th>Beschreibung</th>
+              <th>Aktionen</th>
+            </tr>
+          </thead>
+          <tbody></tbody>
+        </table>
+      </section>
+    </main>
+
+    <template id="command-row-template">
+      <tr>
+        <td class="command"></td>
+        <td class="script"></td>
+        <td class="description"></td>
+        <td>
+          <button class="delete">Löschen</button>
+        </td>
+      </tr>
+    </template>
+
+    <script src="main.js"></script>
+  </body>
+</html>

--- a/public/main.js
+++ b/public/main.js
@@ -1,0 +1,104 @@
+async function fetchConfig() {
+  const response = await fetch('/api/config');
+  if (!response.ok) {
+    throw new Error('Konfiguration konnte nicht geladen werden');
+  }
+  return response.json();
+}
+
+async function saveSection(endpoint, data) {
+  const response = await fetch(endpoint, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data)
+  });
+
+  if (!response.ok) {
+    const payload = await response.json();
+    throw new Error(payload.message || 'Fehler beim Speichern');
+  }
+
+  return response.json();
+}
+
+function fillForm(form, data) {
+  Object.entries(data).forEach(([key, value]) => {
+    if (form.elements[key]) {
+      form.elements[key].value = value ?? '';
+    }
+  });
+}
+
+function renderMappings(mappings) {
+  const tbody = document.querySelector('#command-table tbody');
+  const template = document.querySelector('#command-row-template');
+  tbody.innerHTML = '';
+  mappings.forEach(mapping => {
+    const fragment = template.content.cloneNode(true);
+    fragment.querySelector('.command').textContent = mapping.command;
+    fragment.querySelector('.script').textContent = mapping.scriptName;
+    fragment.querySelector('.description').textContent = mapping.description || '';
+    fragment.querySelector('.delete').addEventListener('click', async () => {
+      await fetch(`/api/config/commands/${encodeURIComponent(mapping.command)}`, {
+        method: 'DELETE'
+      });
+      const config = await fetchConfig();
+      renderMappings(config.commandMappings);
+    });
+    tbody.appendChild(fragment);
+  });
+}
+
+async function init() {
+  try {
+    const config = await fetchConfig();
+    fillForm(document.getElementById('twitch-form'), config.twitch);
+    fillForm(document.getElementById('minecraft-form'), config.minecraft);
+    renderMappings(config.commandMappings);
+  } catch (error) {
+    alert(error.message);
+  }
+
+  document.getElementById('twitch-form').addEventListener('submit', async event => {
+    event.preventDefault();
+    const form = event.currentTarget;
+    const data = Object.fromEntries(new FormData(form).entries());
+    try {
+      await saveSection('/api/config/twitch', data);
+      alert('Twitch Konfiguration gespeichert');
+    } catch (error) {
+      alert(error.message);
+    }
+  });
+
+  document.getElementById('minecraft-form').addEventListener('submit', async event => {
+    event.preventDefault();
+    const form = event.currentTarget;
+    const data = Object.fromEntries(new FormData(form).entries());
+    if (data.rconPort) {
+      data.rconPort = Number(data.rconPort);
+    }
+    try {
+      await saveSection('/api/config/minecraft', data);
+      alert('Minecraft Konfiguration gespeichert');
+    } catch (error) {
+      alert(error.message);
+    }
+  });
+
+  document.getElementById('command-form').addEventListener('submit', async event => {
+    event.preventDefault();
+    const form = event.currentTarget;
+    const data = Object.fromEntries(new FormData(form).entries());
+    try {
+      await saveSection('/api/config/commands', data);
+      form.reset();
+      const config = await fetchConfig();
+      renderMappings(config.commandMappings);
+    } catch (error) {
+      alert(error.message);
+    }
+  });
+}
+
+document.addEventListener('DOMContentLoaded', init);

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,0 +1,107 @@
+:root {
+  color-scheme: light dark;
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background-color: #121212;
+  color: #f5f5f5;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: radial-gradient(circle at top, #2d2f55, #121212 60%);
+}
+
+.container {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+section {
+  background: rgba(0, 0, 0, 0.6);
+  border-radius: 16px;
+  padding: 1.5rem;
+  box-shadow: 0 20px 50px rgba(0, 0, 0, 0.4);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+h1,
+ h2 {
+  margin-top: 0;
+  letter-spacing: 0.05em;
+}
+
+form {
+  display: grid;
+  gap: 1rem;
+}
+
+.form-row {
+  display: grid;
+  gap: 0.5rem;
+}
+
+label {
+  font-weight: 600;
+  text-transform: uppercase;
+  font-size: 0.85rem;
+  opacity: 0.8;
+}
+
+input {
+  padding: 0.75rem 1rem;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  background: rgba(255, 255, 255, 0.05);
+  color: inherit;
+}
+
+button {
+  justify-self: flex-start;
+  padding: 0.75rem 1.5rem;
+  border-radius: 999px;
+  border: none;
+  background: linear-gradient(135deg, #9f5eff, #ff6ec7);
+  color: #fff;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+button:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 15px 30px rgba(159, 94, 255, 0.35);
+}
+
+#command-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 1rem;
+}
+
+#command-table th,
+#command-table td {
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+#command-table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.delete {
+  background: linear-gradient(135deg, #ff5e7e, #ff9966);
+}
+
+@media (max-width: 600px) {
+  .container {
+    padding: 1rem;
+  }
+
+  section {
+    padding: 1rem;
+  }
+}

--- a/src/eventBridge.js
+++ b/src/eventBridge.js
@@ -1,0 +1,63 @@
+const EventEmitter = require('events');
+const { loadConfig } = require('./server');
+
+class EventBridge extends EventEmitter {
+  constructor() {
+    super();
+    this.config = loadConfig();
+  }
+
+  refreshConfig() {
+    this.config = loadConfig();
+    this.emit('configUpdated', this.config);
+  }
+
+  getTwitchSettings() {
+    return { ...this.config.twitch };
+  }
+
+  getMinecraftSettings() {
+    return { ...this.config.minecraft };
+  }
+
+  getCommandMappings() {
+    return [...this.config.commandMappings];
+  }
+
+  mapChatCommand(chatCommand) {
+    return this.config.commandMappings.find(
+      entry => entry.command.toLowerCase() === chatCommand.toLowerCase()
+    );
+  }
+
+  createTwitchEventPayload(message) {
+    const mapping = this.mapChatCommand(message);
+    if (!mapping) {
+      return null;
+    }
+    return {
+      origin: 'twitch',
+      command: mapping.command,
+      scriptName: mapping.scriptName,
+      description: mapping.description,
+      timestamp: new Date().toISOString()
+    };
+  }
+
+  createMinecraftTrigger(mapping) {
+    if (!mapping) {
+      return null;
+    }
+
+    const minecraftConfig = this.getMinecraftSettings();
+    return {
+      ...minecraftConfig,
+      scriptToTrigger: mapping.scriptName,
+      command: mapping.command,
+      description: mapping.description,
+      triggerType: 'script'
+    };
+  }
+}
+
+module.exports = { EventBridge };

--- a/src/server.js
+++ b/src/server.js
@@ -1,0 +1,213 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+const { URL } = require('url');
+
+const CONFIG_PATH = path.join(__dirname, '..', 'config', 'settings.json');
+const PUBLIC_DIR = path.join(__dirname, '..', 'public');
+
+const defaultConfig = {
+  twitch: {
+    username: '',
+    clientId: '',
+    clientSecret: '',
+    oauthToken: '',
+    channel: ''
+  },
+  minecraft: {
+    host: '',
+    rconPort: 25575,
+    rconPassword: '',
+    scriptBasePath: ''
+  },
+  commandMappings: []
+};
+
+function loadConfig() {
+  if (!fs.existsSync(CONFIG_PATH)) {
+    return { ...defaultConfig };
+  }
+  try {
+    const data = fs.readFileSync(CONFIG_PATH, 'utf-8');
+    return { ...defaultConfig, ...JSON.parse(data) };
+  } catch (error) {
+    console.error('Failed to read configuration file:', error);
+    return { ...defaultConfig };
+  }
+}
+
+function saveConfig(config) {
+  const safeConfig = {
+    ...defaultConfig,
+    ...config,
+    twitch: { ...defaultConfig.twitch, ...config.twitch },
+    minecraft: { ...defaultConfig.minecraft, ...config.minecraft },
+    commandMappings: Array.isArray(config.commandMappings)
+      ? config.commandMappings
+      : defaultConfig.commandMappings
+  };
+
+  fs.writeFileSync(CONFIG_PATH, JSON.stringify(safeConfig, null, 2));
+  return safeConfig;
+}
+
+function parseBody(req) {
+  return new Promise((resolve, reject) => {
+    let body = '';
+    req.on('data', chunk => {
+      body += chunk;
+      if (body.length > 1e6) {
+        req.connection.destroy();
+        reject(new Error('Request body too large'));
+      }
+    });
+    req.on('end', () => {
+      try {
+        const parsed = body ? JSON.parse(body) : {};
+        resolve(parsed);
+      } catch (error) {
+        reject(error);
+      }
+    });
+    req.on('error', reject);
+  });
+}
+
+function sendJson(res, statusCode, payload) {
+  res.writeHead(statusCode, {
+    'Content-Type': 'application/json',
+    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Methods': 'GET,POST,PUT,DELETE,OPTIONS',
+    'Access-Control-Allow-Headers': 'Content-Type'
+  });
+  res.end(JSON.stringify(payload));
+}
+
+function handleOptions(res) {
+  res.writeHead(204, {
+    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Methods': 'GET,POST,PUT,DELETE,OPTIONS',
+    'Access-Control-Allow-Headers': 'Content-Type'
+  });
+  res.end();
+}
+
+function serveStatic(res, pathname) {
+  const filePath = path.join(PUBLIC_DIR, pathname === '/' ? 'index.html' : pathname);
+  if (!filePath.startsWith(PUBLIC_DIR)) {
+    res.writeHead(403);
+    res.end('Forbidden');
+    return;
+  }
+
+  fs.readFile(filePath, (err, content) => {
+    if (err) {
+      res.writeHead(404);
+      res.end('Not Found');
+      return;
+    }
+    const ext = path.extname(filePath);
+    const mimeTypes = {
+      '.html': 'text/html',
+      '.css': 'text/css',
+      '.js': 'application/javascript',
+      '.json': 'application/json'
+    };
+    res.writeHead(200, { 'Content-Type': mimeTypes[ext] || 'text/plain' });
+    res.end(content);
+  });
+}
+
+const server = http.createServer(async (req, res) => {
+  const parsedUrl = new URL(req.url, `http://${req.headers.host}`);
+  const { pathname } = parsedUrl;
+
+  if (req.method === 'OPTIONS') {
+    handleOptions(res);
+    return;
+  }
+
+  if (pathname.startsWith('/api/config')) {
+    let config = loadConfig();
+
+    try {
+      if (req.method === 'GET' && pathname === '/api/config') {
+        sendJson(res, 200, config);
+        return;
+      }
+
+      if (req.method === 'POST' && pathname === '/api/config/twitch') {
+        const body = await parseBody(req);
+        config = saveConfig({
+          ...config,
+          twitch: { ...config.twitch, ...body }
+        });
+        sendJson(res, 200, config.twitch);
+        return;
+      }
+
+      if (req.method === 'POST' && pathname === '/api/config/minecraft') {
+        const body = await parseBody(req);
+        config = saveConfig({
+          ...config,
+          minecraft: { ...config.minecraft, ...body }
+        });
+        sendJson(res, 200, config.minecraft);
+        return;
+      }
+
+      if (req.method === 'POST' && pathname === '/api/config/commands') {
+        const body = await parseBody(req);
+        const { command, scriptName, description } = body;
+        if (!command || !scriptName) {
+          sendJson(res, 400, { message: 'command and scriptName are required.' });
+          return;
+        }
+        const existingIndex = config.commandMappings.findIndex(
+          entry => entry.command === command
+        );
+        if (existingIndex >= 0) {
+          config.commandMappings[existingIndex] = {
+            ...config.commandMappings[existingIndex],
+            scriptName,
+            description: description || ''
+          };
+        } else {
+          config.commandMappings.push({
+            command,
+            scriptName,
+            description: description || ''
+          });
+        }
+        saveConfig(config);
+        sendJson(res, 200, config.commandMappings);
+        return;
+      }
+
+      if (req.method === 'DELETE' && pathname.startsWith('/api/config/commands/')) {
+        const command = decodeURIComponent(pathname.split('/').pop());
+        const newMappings = config.commandMappings.filter(entry => entry.command !== command);
+        config.commandMappings = newMappings;
+        saveConfig(config);
+        sendJson(res, 200, newMappings);
+        return;
+      }
+    } catch (error) {
+      console.error('API error', error);
+      sendJson(res, 500, { message: 'Internal server error', error: error.message });
+      return;
+    }
+
+    sendJson(res, 404, { message: 'Not found' });
+    return;
+  }
+
+  serveStatic(res, pathname);
+});
+
+const PORT = process.env.PORT || 3000;
+server.listen(PORT, () => {
+  console.log(`Configuration service listening on port ${PORT}`);
+});
+
+module.exports = { server, loadConfig, saveConfig };


### PR DESCRIPTION
## Summary
- add a Node.js HTTP server that exposes REST endpoints for Twitch, Minecraft, and command mapping configuration
- provide a static web interface for editing configuration data and persisting it to a JSON file
- include an EventBridge helper for translating chat commands into Minecraft trigger payloads

## Testing
- node src/server.js

------
https://chatgpt.com/codex/tasks/task_e_68dfd324bc20832f94decb03c4f1728b