### PR TITLE
Improve chat console and configuration guidance

### DIFF
--- a/public/chat-log.html
+++ b/public/chat-log.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<html lang="de">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Chat Log • Event Bridge</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body class="chat-log-body">
+    <main class="container chat-log-container">
+      <header class="chat-log-header">
+        <div>
+          <h1>Chat Konsole</h1>
+          <p class="section-intro">
+            Beobachte alle eintreffenden Nachrichten in Echtzeit und verschicke Antworten mit deinem
+            konfigurierten Bot-Konto.
+          </p>
+        </div>
+        <a class="nav-link" href="index.html">Zurück zur Konfiguration</a>
+      </header>
+
+      <section class="chat-console-card">
+        <header class="section-header">
+          <div>
+            <h2>Live Log</h2>
+            <p class="section-subtitle">Die Konsole zeigt Twitch IRC Ereignisse unmittelbar nach ihrem Eingang.</p>
+          </div>
+          <span class="status-chip status-chip--disconnected" id="chat-connection-chip">Offline</span>
+        </header>
+        <div
+          class="chat-console"
+          id="chat-console"
+          role="log"
+          aria-live="polite"
+          aria-busy="true"
+          aria-label="Live Chat Konsole"
+        ></div>
+        <div class="chat-console-actions">
+          <button type="button" id="clear-log" class="ghost-button">Konsole leeren</button>
+          <span class="status-message" id="chat-status" role="status" aria-live="polite"></span>
+        </div>
+      </section>
+
+      <section class="chat-send-card">
+        <header class="section-header">
+          <div>
+            <h2>Nachrichten senden</h2>
+            <p class="section-subtitle">
+              Antworten werden automatisch unter deinem Bot-Benutzernamen veröffentlicht.
+            </p>
+          </div>
+          <button type="button" class="ghost-button" id="reload-identity">Konfiguration neu laden</button>
+        </header>
+        <p class="form-hint">
+          Aktives Konto:
+          <strong id="chat-identity">Keine Twitch Konfiguration gefunden</strong>.
+          Die Daten stammen aus der <a href="index.html">Twitch Schnittstelle</a>.
+        </p>
+        <form id="chat-send-form" autocomplete="off">
+          <input type="hidden" id="chat-username" name="username" />
+          <div class="form-row">
+            <label for="chat-message">Nachricht</label>
+            <input
+              id="chat-message"
+              name="message"
+              placeholder="Hallo Chat 👋"
+              maxlength="500"
+              required
+            />
+          </div>
+          <div class="form-actions">
+            <button type="submit" id="send-button">Nachricht senden</button>
+            <button type="button" class="secondary-button" id="preview-test">Testeintrag simulieren</button>
+          </div>
+        </form>
+      </section>
+
+      <section class="chat-hints">
+        <h2>Tipps für die Integration</h2>
+        <ul class="helper-list">
+          <li>
+            Stelle sicher, dass der Bot-Account in der Twitch Konfiguration mit einem gültigen OAuth Token
+            versehen ist. Der Token benötigt mindestens den Scope <code>chat:read</code> und
+            <code>chat:edit</code>.
+          </li>
+          <li>
+            Ein externer Prozess kann Nachrichten an <code>POST /api/chat/message</code> schicken, um die
+            Konsole zu befüllen. Diese Seite verbindet sich per Server-Sent Events mit
+            <code>/api/chat/stream</code>.
+          </li>
+          <li>
+            Über <code>DELETE /api/chat</code> lassen sich alle Log-Einträge synchron löschen – nützlich für
+            den Start eines neuen Streams.
+          </li>
+        </ul>
+      </section>
+    </main>
+
+    <script src="chat-log.js"></script>
+  </body>
+</html>

--- a/public/chat-log.js
+++ b/public/chat-log.js
@@ -1,0 +1,305 @@
+const consoleElement = document.getElementById('chat-console');
+const statusElement = document.getElementById('chat-status');
+const connectionChip = document.getElementById('chat-connection-chip');
+const sendForm = document.getElementById('chat-send-form');
+const messageInput = document.getElementById('chat-message');
+const usernameInput = document.getElementById('chat-username');
+const sendButton = document.getElementById('send-button');
+const reloadIdentityButton = document.getElementById('reload-identity');
+const clearButton = document.getElementById('clear-log');
+const previewButton = document.getElementById('preview-test');
+const identityLabel = document.getElementById('chat-identity');
+
+const seenEntryIds = new Set();
+let emptyStateElement = null;
+let currentIdentity = '';
+let eventSource = null;
+let connectionState = 'disconnected';
+
+const timeFormatter = new Intl.DateTimeFormat('de-DE', {
+  hour: '2-digit',
+  minute: '2-digit',
+  second: '2-digit'
+});
+
+function ensureEmptyState() {
+  if (!consoleElement) {
+    return;
+  }
+
+  if (!consoleElement.childElementCount) {
+    if (!emptyStateElement) {
+      emptyStateElement = document.createElement('p');
+      emptyStateElement.className = 'console-empty-state';
+      emptyStateElement.textContent = 'Warte auf eingehende Nachrichten …';
+    }
+    consoleElement.appendChild(emptyStateElement);
+  } else if (emptyStateElement && emptyStateElement.parentElement === consoleElement) {
+    consoleElement.removeChild(emptyStateElement);
+  }
+}
+
+function setStatus(message, tone = 'info') {
+  if (!statusElement) {
+    return;
+  }
+  statusElement.textContent = message;
+  statusElement.dataset.tone = tone;
+}
+
+function updateConnectionChip(state) {
+  connectionState = state;
+  const classList = connectionChip.classList;
+  classList.remove('status-chip--connected', 'status-chip--reconnecting', 'status-chip--disconnected');
+
+  switch (state) {
+    case 'connected':
+      classList.add('status-chip--connected');
+      connectionChip.textContent = 'Live';
+      consoleElement?.setAttribute('aria-busy', 'false');
+      break;
+    case 'reconnecting':
+      classList.add('status-chip--reconnecting');
+      connectionChip.textContent = 'Neu verbinden…';
+      consoleElement?.setAttribute('aria-busy', 'true');
+      break;
+    default:
+      classList.add('status-chip--disconnected');
+      connectionChip.textContent = 'Offline';
+      consoleElement?.setAttribute('aria-busy', 'true');
+  }
+}
+
+function renderEntry(entry) {
+  if (!entry || !entry.id || seenEntryIds.has(entry.id)) {
+    return;
+  }
+
+  seenEntryIds.add(entry.id);
+  if (emptyStateElement?.parentElement === consoleElement) {
+    consoleElement.removeChild(emptyStateElement);
+  }
+
+  const wrapper = document.createElement('div');
+  wrapper.className = 'console-line';
+  if (entry.direction) {
+    wrapper.classList.add(`console-line--${entry.direction}`);
+  }
+
+  const meta = document.createElement('span');
+  meta.className = 'console-line__meta';
+  const icon = entry.direction === 'outgoing' ? '⇢' : entry.direction === 'incoming' ? '⇠' : '•';
+  const transportLabel = entry.transport ? `@${entry.transport}` : '';
+  meta.textContent = `[${timeFormatter.format(new Date(entry.timestamp))}] ${icon} ${
+    entry.username || 'Unbekannt'
+  } ${transportLabel}`.trim();
+
+  const message = document.createElement('span');
+  message.className = 'console-line__message';
+  message.textContent = entry.message || '';
+
+  wrapper.append(meta, message);
+  consoleElement.appendChild(wrapper);
+  consoleElement.scrollTo({ top: consoleElement.scrollHeight, behavior: 'smooth' });
+}
+
+async function loadIdentity() {
+  try {
+    setStatus('Lade Twitch Konfiguration …', 'info');
+    const response = await fetch('/api/config');
+    if (!response.ok) {
+      throw new Error('Konfiguration nicht erreichbar');
+    }
+    const config = await response.json();
+    const username = config?.twitch?.username?.trim();
+    currentIdentity = username || '';
+    usernameInput.value = currentIdentity;
+
+    if (currentIdentity) {
+      identityLabel.textContent = currentIdentity;
+      sendButton.disabled = false;
+      messageInput.disabled = false;
+      setStatus(`Sende als ${currentIdentity}.`, 'success');
+    } else {
+      identityLabel.textContent = 'Bitte Benutzername in der Konfiguration hinterlegen';
+      sendButton.disabled = true;
+      messageInput.disabled = true;
+      setStatus('Kein Twitch Benutzer gefunden. Bitte Konfiguration prüfen.', 'error');
+    }
+  } catch (error) {
+    console.error('Failed to load identity', error);
+    identityLabel.textContent = 'Konfiguration konnte nicht geladen werden';
+    sendButton.disabled = true;
+    messageInput.disabled = true;
+    setStatus(`Konfiguration konnte nicht geladen werden: ${error.message}`, 'error');
+  }
+}
+
+function connectToStream() {
+  if (eventSource) {
+    eventSource.close();
+  }
+
+  ensureEmptyState();
+  updateConnectionChip('reconnecting');
+  setStatus('Verbinde mit dem Chat Stream …', 'info');
+
+  eventSource = new EventSource('/api/chat/stream');
+
+  eventSource.onopen = () => {
+    const wasConnected = connectionState === 'connected';
+    updateConnectionChip('connected');
+    if (!wasConnected) {
+      setStatus('Mit dem Chat Stream verbunden.', 'success');
+    }
+  };
+
+  eventSource.addEventListener('message', event => {
+    try {
+      const payload = JSON.parse(event.data);
+      renderEntry(payload);
+    } catch (error) {
+      console.error('Failed to parse chat entry', error);
+    }
+  });
+
+  eventSource.addEventListener('clear', () => {
+    seenEntryIds.clear();
+    consoleElement.innerHTML = '';
+    ensureEmptyState();
+    setStatus('Konsole geleert.', 'info');
+  });
+
+  eventSource.onerror = () => {
+    updateConnectionChip('reconnecting');
+    setStatus('Verbindung unterbrochen – erneuter Versuch in Kürze …', 'error');
+  };
+}
+
+async function postChatMessage(payload) {
+  const response = await fetch('/api/chat/message', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload)
+  });
+
+  if (!response.ok) {
+    const errorPayload = await response.json().catch(() => ({ message: 'Unbekannter Fehler' }));
+    throw new Error(errorPayload.message || 'Fehler beim Senden');
+  }
+
+  return response.json();
+}
+
+sendForm.addEventListener('submit', async event => {
+  event.preventDefault();
+  if (!currentIdentity) {
+    setStatus('Bitte konfiguriere zuerst einen Twitch Benutzer.', 'error');
+    return;
+  }
+
+  const message = messageInput.value.trim();
+  if (!message) {
+    return;
+  }
+
+  try {
+    sendButton.disabled = true;
+    setStatus('Sende Nachricht …', 'info');
+    await postChatMessage({
+      username: currentIdentity,
+      message,
+      direction: 'outgoing',
+      transport: 'twitch'
+    });
+    messageInput.value = '';
+    setStatus('Nachricht an den Chat übermittelt (lokales Protokoll).', 'success');
+  } catch (error) {
+    console.error('Failed to send chat message', error);
+    setStatus(`Fehler beim Senden: ${error.message}`, 'error');
+  } finally {
+    sendButton.disabled = !currentIdentity;
+    messageInput.disabled = !currentIdentity;
+    if (currentIdentity) {
+      messageInput.focus();
+    }
+  }
+});
+
+clearButton.addEventListener('click', async () => {
+  try {
+    setStatus('Leere Konsole …', 'info');
+    const response = await fetch('/api/chat', { method: 'DELETE' });
+    if (!response.ok) {
+      const payload = await response.json().catch(() => ({ message: 'Unbekannter Fehler' }));
+      throw new Error(payload.message || 'Fehler beim Bereinigen');
+    }
+  } catch (error) {
+    console.error('Failed to clear chat', error);
+    setStatus(`Konsole konnte nicht geleert werden: ${error.message}`, 'error');
+  }
+});
+
+reloadIdentityButton.addEventListener('click', () => {
+  loadIdentity();
+});
+
+previewButton.addEventListener('click', async () => {
+  const viewerNames = ['pixelpioneer', 'streamqueen', 'craftmaster', 'redstoner'];
+  const sampleMessages = [
+    'Hey, wann startet das Event?',
+    'GG! Das war mega gut!',
+    'Kannst du den Seed teilen?',
+    'Reminder: Hydration break!'
+  ];
+  const username = viewerNames[Math.floor(Math.random() * viewerNames.length)];
+  const message = sampleMessages[Math.floor(Math.random() * sampleMessages.length)];
+
+  try {
+    setStatus('Füge Testeintrag hinzu …', 'info');
+    await postChatMessage({
+      username,
+      message,
+      direction: 'incoming',
+      transport: 'simulation'
+    });
+    setStatus('Testeintrag erstellt.', 'success');
+  } catch (error) {
+    console.error('Failed to create preview entry', error);
+    setStatus(`Testeintrag fehlgeschlagen: ${error.message}`, 'error');
+  }
+});
+
+window.addEventListener('message', event => {
+  if (event.origin && event.origin !== window.location.origin) {
+    return;
+  }
+  const data = event.data;
+  if (!data || typeof data !== 'object' || data.type !== 'chat-message') {
+    return;
+  }
+  postChatMessage({
+    username: data.payload?.username,
+    message: data.payload?.message,
+    direction: data.payload?.direction || 'incoming',
+    transport: data.payload?.transport || 'external'
+  }).catch(error => {
+    console.error('Failed to post message from window message', error);
+  });
+});
+
+window.chatLog = {
+  addMessage(payload = {}) {
+    return postChatMessage({
+      username: payload.username,
+      message: payload.message,
+      direction: payload.direction || 'incoming',
+      transport: payload.transport || 'external'
+    });
+  }
+};
+
+ensureEmptyState();
+connectToStream();
+loadIdentity();
+messageInput.focus();

--- a/public/index.html
+++ b/public/index.html
@@ -10,73 +10,221 @@
   <body>
     <main class="container">
       <h1>Event Bridge Konfiguration</h1>
-      <section>
-        <h2>Twitch Schnittstelle</h2>
+      <nav class="page-nav">
+        <a class="nav-link" href="chat-log.html">Chat Log ansehen</a>
+      </nav>
+
+      <section class="integration-card">
+        <header class="section-header">
+          <div>
+            <h2>Twitch Schnittstelle</h2>
+            <p class="section-intro">
+              Verbinde dein Bot-Konto mit dem Twitch Chat. Die wichtigsten Felder findest du unten, optionale
+              OAuth-Daten liegen im ausklappbaren Bereich.
+            </p>
+          </div>
+          <div class="doc-links">
+            <a class="doc-link" href="https://dev.twitch.tv/docs/irc" target="_blank" rel="noopener"
+              >Twitch IRC Dokumentation</a
+            >
+            <a
+              class="doc-link"
+              href="https://dev.twitch.tv/docs/authentication/getting-tokens-oauth"
+              target="_blank"
+              rel="noopener"
+              >OAuth Leitfaden</a
+            >
+          </div>
+        </header>
+
         <form id="twitch-form">
-          <div class="form-row">
-            <label for="twitch-username">Benutzername</label>
-            <input id="twitch-username" name="username" required />
+          <div class="form-grid">
+            <div class="form-row">
+              <label for="twitch-username">Bot Benutzername</label>
+              <input id="twitch-username" name="username" placeholder="z.B. vibeCoderBot" required />
+              <p class="field-hint">Der Twitch-Account, der Nachrichten senden und empfangen soll.</p>
+            </div>
+
+            <div class="form-row">
+              <label for="twitch-token">OAuth Token</label>
+              <div class="stacked-input">
+                <input
+                  id="twitch-token"
+                  name="oauthToken"
+                  type="password"
+                  placeholder="oauth:xxxxxxxxxxxxxxxx"
+                />
+                <button type="button" class="secondary-button" id="twitch-oauth-button">
+                  OAuth Token erzeugen
+                </button>
+              </div>
+              <p class="field-hint">
+                Der Button öffnet das offizielle <strong>Twitch Chat OAuth Tool</strong> (twitchapps.com/tmi).
+                Der Token benötigt mindestens die Scopes <code>chat:read</code> und <code>chat:edit</code>.
+              </p>
+            </div>
+
+            <div class="form-row">
+              <label for="twitch-channel">Channel</label>
+              <input id="twitch-channel" name="channel" placeholder="Dein Kanal ohne #" />
+              <p class="field-hint">In diesem Kanal hört der Bot zu und verschickt Nachrichten.</p>
+            </div>
           </div>
-          <div class="form-row">
-            <label for="twitch-clientId">Client ID</label>
-            <input id="twitch-clientId" name="clientId" />
+
+          <details class="details-card">
+            <summary>Erweiterte Einstellungen (optional)</summary>
+            <div class="details-content">
+              <div class="form-row">
+                <label for="twitch-clientId">Client ID</label>
+                <input id="twitch-clientId" name="clientId" placeholder="Client ID deiner Twitch-App" />
+                <p class="field-hint">
+                  Nur erforderlich, wenn du eigene API-Anfragen planst oder Events abonnieren möchtest.
+                </p>
+              </div>
+              <div class="form-row">
+                <label for="twitch-clientSecret">Client Secret</label>
+                <input
+                  id="twitch-clientSecret"
+                  name="clientSecret"
+                  type="password"
+                  placeholder="Client Secret"
+                />
+                <p class="field-hint">Bewahre diesen Wert sicher auf und teile ihn nicht öffentlich.</p>
+              </div>
+            </div>
+          </details>
+
+          <div class="form-actions">
+            <button type="submit">Speichern</button>
+            <button type="button" class="secondary-button" id="twitch-test">Verbindung testen</button>
+            <span class="status-message" id="twitch-status" role="status" aria-live="polite"></span>
           </div>
-          <div class="form-row">
-            <label for="twitch-clientSecret">Client Secret</label>
-            <input id="twitch-clientSecret" name="clientSecret" type="password" />
-          </div>
-          <div class="form-row">
-            <label for="twitch-token">OAuth Token</label>
-            <input id="twitch-token" name="oauthToken" type="password" />
-          </div>
-          <div class="form-row">
-            <label for="twitch-channel">Channel</label>
-            <input id="twitch-channel" name="channel" />
-          </div>
-          <button type="submit">Speichern</button>
         </form>
+
+        <details class="info-card">
+          <summary>Schnellstart &amp; hilfreiche Links</summary>
+          <ol class="helper-list helper-list--ordered">
+            <li>Logge dich mit deinem Bot-Konto ein und generiere den OAuth Token über den Button oben.</li>
+            <li>Trage den Namen des Kanals ein, in dem der Bot aktiv sein soll, und speichere die Einstellungen.</li>
+            <li>Nutze „Verbindung testen“, um zu prüfen, ob die gespeicherten Daten gültig wirken.</li>
+          </ol>
+        </details>
       </section>
 
-      <section>
-        <h2>Minecraft Schnittstelle</h2>
+      <section class="integration-card">
+        <header class="section-header">
+          <div>
+            <h2>Minecraft Schnittstelle</h2>
+            <p class="section-intro">
+              Hinterlege die Zugangsdaten für deinen RCON-Server sowie den Pfad zu ausführbaren Skripten.
+            </p>
+          </div>
+          <div class="doc-links">
+            <a class="doc-link" href="https://minecraft.fandom.com/wiki/RCON" target="_blank" rel="noopener"
+              >RCON Dokumentation</a
+            >
+          </div>
+        </header>
+
         <form id="minecraft-form">
-          <div class="form-row">
-            <label for="minecraft-host">Host</label>
-            <input id="minecraft-host" name="host" />
+          <div class="form-grid form-grid--two">
+            <div class="form-row">
+              <label for="minecraft-host">Host</label>
+              <input id="minecraft-host" name="host" placeholder="z.B. 127.0.0.1" />
+              <p class="field-hint">IP oder Hostname deines Minecraft Servers.</p>
+            </div>
+            <div class="form-row">
+              <label for="minecraft-port">RCON Port</label>
+              <input
+                id="minecraft-port"
+                name="rconPort"
+                type="number"
+                min="1"
+                max="65535"
+                placeholder="25575"
+              />
+              <p class="field-hint">Standard ist 25575. Stelle sicher, dass der Port freigegeben ist.</p>
+            </div>
+            <div class="form-row">
+              <label for="minecraft-password">RCON Passwort</label>
+              <input
+                id="minecraft-password"
+                name="rconPassword"
+                type="password"
+                placeholder="Dein RCON Passwort"
+              />
+              <p class="field-hint">
+                Das Passwort entspricht der Konfiguration in deiner <code>server.properties</code>.
+              </p>
+            </div>
+            <div class="form-row">
+              <label for="minecraft-scriptBasePath">Script Basis Pfad</label>
+              <input
+                id="minecraft-scriptBasePath"
+                name="scriptBasePath"
+                placeholder="/opt/event-skripte"
+              />
+              <p class="field-hint">Ordner, in dem deine Automationsskripte liegen.</p>
+            </div>
           </div>
-          <div class="form-row">
-            <label for="minecraft-port">RCON Port</label>
-            <input id="minecraft-port" name="rconPort" type="number" min="1" max="65535" />
+          <div class="form-actions">
+            <button type="submit">Speichern</button>
+            <button type="button" class="secondary-button" id="minecraft-test">Verbindung testen</button>
+            <span class="status-message" id="minecraft-status" role="status" aria-live="polite"></span>
           </div>
-          <div class="form-row">
-            <label for="minecraft-password">RCON Passwort</label>
-            <input id="minecraft-password" name="rconPassword" type="password" />
-          </div>
-          <div class="form-row">
-            <label for="minecraft-scriptBasePath">Script Basis Pfad</label>
-            <input id="minecraft-scriptBasePath" name="scriptBasePath" />
-          </div>
-          <button type="submit">Speichern</button>
         </form>
+
+        <details class="info-card">
+          <summary>Konfigurationshilfe</summary>
+          <ul class="helper-list">
+            <li>Aktiviere <code>enable-rcon=true</code> in deiner <code>server.properties</code>.</li>
+            <li>Setze <code>rcon.password</code> auf ein sicheres Passwort und übernimm den Wert hier im Formular.</li>
+            <li>Lege deine Skripte im angegebenen Basis-Pfad ab und stelle sicher, dass der Webserver Zugriffsrechte hat.</li>
+          </ul>
+        </details>
       </section>
 
-      <section>
-        <h2>Command Mapping</h2>
+      <section class="integration-card">
+        <header class="section-header">
+          <div>
+            <h2>Command Mapping</h2>
+            <p class="section-intro">
+              Verknüpfe Chatbefehle mit Skripten auf deinem Server. Diese Zuordnung bildet die Grundlage für
+              Automatisierung.
+            </p>
+          </div>
+          <div class="doc-links">
+            <a
+              class="doc-link"
+              href="https://minecraft.fandom.com/wiki/Commands"
+              target="_blank"
+              rel="noopener"
+              >Übersicht Minecraft Befehle</a
+            >
+          </div>
+        </header>
+
         <form id="command-form">
           <div class="form-row">
             <label for="command-command">Chat Befehl</label>
             <input id="command-command" name="command" placeholder="z.B. !start" required />
+            <p class="field-hint">Der Text, den Zuschauer:innen im Chat eingeben.</p>
           </div>
           <div class="form-row">
             <label for="command-script">Script Name</label>
             <input id="command-script" name="scriptName" placeholder="z.B. start_event.sh" required />
+            <p class="field-hint">Dateiname inklusive Endung. Das Skript wird relativ zum Basis-Pfad ausgeführt.</p>
           </div>
           <div class="form-row">
             <label for="command-description">Beschreibung</label>
             <input id="command-description" name="description" placeholder="Optionale Beschreibung" />
           </div>
-          <button type="submit">Hinzufügen / Aktualisieren</button>
+          <div class="form-actions">
+            <button type="submit">Hinzufügen / Aktualisieren</button>
+            <span class="status-message" id="command-status" role="status" aria-live="polite"></span>
+          </div>
         </form>
+
         <table id="command-table">
           <thead>
             <tr>

--- a/public/main.js
+++ b/public/main.js
@@ -1,3 +1,11 @@
+function setStatus(element, message, tone = 'info') {
+  if (!element) {
+    return;
+  }
+  element.textContent = message;
+  element.dataset.tone = tone;
+}
+
 async function fetchConfig() {
   const response = await fetch('/api/config');
   if (!response.ok) {
@@ -14,10 +22,19 @@ async function saveSection(endpoint, data) {
   });
 
   if (!response.ok) {
-    const payload = await response.json();
+    const payload = await response.json().catch(() => ({ message: 'Unbekannter Fehler' }));
     throw new Error(payload.message || 'Fehler beim Speichern');
   }
 
+  return response.json();
+}
+
+async function testConnection(endpoint) {
+  const response = await fetch(endpoint);
+  if (!response.ok) {
+    const payload = await response.json().catch(() => ({ message: 'Unbekannter Fehler' }));
+    throw new Error(payload.message || 'Verbindungstest fehlgeschlagen');
+  }
   return response.json();
 }
 
@@ -32,6 +49,7 @@ function fillForm(form, data) {
 function renderMappings(mappings) {
   const tbody = document.querySelector('#command-table tbody');
   const template = document.querySelector('#command-row-template');
+  const status = document.getElementById('command-status');
   tbody.innerHTML = '';
   mappings.forEach(mapping => {
     const fragment = template.content.cloneNode(true);
@@ -39,35 +57,75 @@ function renderMappings(mappings) {
     fragment.querySelector('.script').textContent = mapping.scriptName;
     fragment.querySelector('.description').textContent = mapping.description || '';
     fragment.querySelector('.delete').addEventListener('click', async () => {
-      await fetch(`/api/config/commands/${encodeURIComponent(mapping.command)}`, {
-        method: 'DELETE'
-      });
-      const config = await fetchConfig();
-      renderMappings(config.commandMappings);
+      try {
+        await fetch(`/api/config/commands/${encodeURIComponent(mapping.command)}`, {
+          method: 'DELETE'
+        });
+        const config = await fetchConfig();
+        renderMappings(config.commandMappings);
+        setStatus(status, `Mapping ${mapping.command} entfernt.`, 'success');
+      } catch (error) {
+        setStatus(status, error.message, 'error');
+      }
     });
     tbody.appendChild(fragment);
   });
 }
 
 async function init() {
+  const twitchStatus = document.getElementById('twitch-status');
+  const minecraftStatus = document.getElementById('minecraft-status');
+  const commandStatus = document.getElementById('command-status');
+
   try {
     const config = await fetchConfig();
     fillForm(document.getElementById('twitch-form'), config.twitch);
     fillForm(document.getElementById('minecraft-form'), config.minecraft);
     renderMappings(config.commandMappings);
   } catch (error) {
-    alert(error.message);
+    setStatus(twitchStatus, error.message, 'error');
+    setStatus(minecraftStatus, error.message, 'error');
+    setStatus(commandStatus, error.message, 'error');
   }
+
+  const usernameField = document.getElementById('twitch-username');
+  const channelField = document.getElementById('twitch-channel');
+  usernameField.addEventListener('blur', () => {
+    const username = usernameField.value.trim();
+    if (username && !channelField.value.trim()) {
+      channelField.value = username.toLowerCase();
+    }
+  });
+
+  document.getElementById('twitch-oauth-button').addEventListener('click', () => {
+    setStatus(twitchStatus, 'Öffne Twitch OAuth Tool …', 'info');
+    window.open('https://twitchapps.com/tmi/', '_blank', 'noopener');
+  });
 
   document.getElementById('twitch-form').addEventListener('submit', async event => {
     event.preventDefault();
     const form = event.currentTarget;
     const data = Object.fromEntries(new FormData(form).entries());
     try {
+      setStatus(twitchStatus, 'Speichere Twitch Einstellungen …', 'info');
       await saveSection('/api/config/twitch', data);
-      alert('Twitch Konfiguration gespeichert');
+      setStatus(twitchStatus, 'Twitch Konfiguration gespeichert.', 'success');
     } catch (error) {
-      alert(error.message);
+      setStatus(twitchStatus, error.message, 'error');
+    }
+  });
+
+  document.getElementById('twitch-test').addEventListener('click', async () => {
+    setStatus(twitchStatus, 'Prüfe Verbindung …', 'info');
+    try {
+      const result = await testConnection('/api/test/twitch');
+      setStatus(
+        twitchStatus,
+        `${result.service}: ${result.status.toUpperCase()} (${new Date(result.timestamp).toLocaleTimeString()})`,
+        'success'
+      );
+    } catch (error) {
+      setStatus(twitchStatus, error.message, 'error');
     }
   });
 
@@ -79,10 +137,25 @@ async function init() {
       data.rconPort = Number(data.rconPort);
     }
     try {
+      setStatus(minecraftStatus, 'Speichere Minecraft Einstellungen …', 'info');
       await saveSection('/api/config/minecraft', data);
-      alert('Minecraft Konfiguration gespeichert');
+      setStatus(minecraftStatus, 'Minecraft Konfiguration gespeichert.', 'success');
     } catch (error) {
-      alert(error.message);
+      setStatus(minecraftStatus, error.message, 'error');
+    }
+  });
+
+  document.getElementById('minecraft-test').addEventListener('click', async () => {
+    setStatus(minecraftStatus, 'Prüfe Verbindung …', 'info');
+    try {
+      const result = await testConnection('/api/test/minecraft');
+      setStatus(
+        minecraftStatus,
+        `${result.service}: ${result.status.toUpperCase()} (${new Date(result.timestamp).toLocaleTimeString()})`,
+        'success'
+      );
+    } catch (error) {
+      setStatus(minecraftStatus, error.message, 'error');
     }
   });
 
@@ -91,12 +164,14 @@ async function init() {
     const form = event.currentTarget;
     const data = Object.fromEntries(new FormData(form).entries());
     try {
+      setStatus(commandStatus, 'Speichere Mapping …', 'info');
       await saveSection('/api/config/commands', data);
       form.reset();
       const config = await fetchConfig();
       renderMappings(config.commandMappings);
+      setStatus(commandStatus, 'Mapping gespeichert.', 'success');
     } catch (error) {
-      alert(error.message);
+      setStatus(commandStatus, error.message, 'error');
     }
   });
 }

--- a/public/styles.css
+++ b/public/styles.css
@@ -11,6 +11,10 @@ body {
   background: radial-gradient(circle at top, #2d2f55, #121212 60%);
 }
 
+.chat-log-body {
+  background: linear-gradient(160deg, rgba(30, 33, 68, 0.95), rgba(16, 17, 35, 0.98));
+}
+
 .container {
   max-width: 960px;
   margin: 0 auto;
@@ -20,12 +24,99 @@ body {
   gap: 2rem;
 }
 
+.integration-card,
+.chat-console-card,
+.chat-send-card {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.chat-log-container {
+  gap: 1.5rem;
+}
+
+.chat-log-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.page-nav {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.nav-link {
+  color: #ffb0ff;
+  text-decoration: none;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  padding: 0.5rem 1rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.nav-link:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 20px rgba(255, 176, 255, 0.25);
+}
+
 section {
   background: rgba(0, 0, 0, 0.6);
   border-radius: 16px;
   padding: 1.5rem;
   box-shadow: 0 20px 50px rgba(0, 0, 0, 0.4);
   border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.section-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1.5rem;
+  flex-wrap: wrap;
+}
+
+.section-intro {
+  margin: 0.5rem 0 0;
+  opacity: 0.75;
+  line-height: 1.5;
+}
+
+.section-subtitle {
+  margin: 0.35rem 0 0;
+  opacity: 0.7;
+  font-size: 0.9rem;
+  line-height: 1.4;
+}
+
+.doc-links {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.doc-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.4rem 0.85rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+  color: #f5f5ff;
+  font-size: 0.85rem;
+  letter-spacing: 0.03em;
+  text-decoration: none;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.doc-link:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 24px rgba(255, 255, 255, 0.18);
 }
 
 h1,
@@ -39,6 +130,20 @@ form {
   gap: 1rem;
 }
 
+.form-grid {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.form-grid--two {
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.stacked-input {
+  display: grid;
+  gap: 0.75rem;
+}
+
 .form-row {
   display: grid;
   gap: 0.5rem;
@@ -49,6 +154,13 @@ label {
   text-transform: uppercase;
   font-size: 0.85rem;
   opacity: 0.8;
+}
+
+.field-hint {
+  margin: 0.25rem 0 0;
+  font-size: 0.8rem;
+  opacity: 0.7;
+  line-height: 1.4;
 }
 
 input {
@@ -76,6 +188,225 @@ button:hover {
   box-shadow: 0 15px 30px rgba(159, 94, 255, 0.35);
 }
 
+.form-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+button.secondary-button {
+  background: linear-gradient(135deg, #4cc2ff, #7cf7ff);
+  color: #0a0a0a;
+}
+
+button.secondary-button:hover {
+  box-shadow: 0 12px 24px rgba(124, 247, 255, 0.35);
+}
+
+button.ghost-button {
+  background: transparent;
+  border: 1px solid rgba(255, 255, 255, 0.35);
+  color: inherit;
+  box-shadow: none;
+}
+
+button.ghost-button:hover {
+  background: rgba(255, 255, 255, 0.08);
+  box-shadow: none;
+}
+
+button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: none;
+}
+
+button.ghost-button:disabled {
+  border-color: rgba(255, 255, 255, 0.15);
+}
+
+button.secondary-button:disabled {
+  background: rgba(124, 247, 255, 0.2);
+  color: rgba(10, 10, 10, 0.6);
+}
+
+.status-message {
+  min-height: 1.5rem;
+  font-size: 0.85rem;
+  letter-spacing: 0.03em;
+  opacity: 0.85;
+}
+
+.status-message[data-tone='success'] {
+  color: #7cf7ff;
+}
+
+.status-message[data-tone='error'] {
+  color: #ff8ab7;
+}
+
+.status-message[data-tone='info'] {
+  color: #d5d5ff;
+}
+
+.details-card,
+.info-card {
+  margin-top: 1.5rem;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 14px;
+  padding: 1rem 1.25rem;
+}
+
+.details-card summary,
+.info-card summary {
+  cursor: pointer;
+  font-weight: 600;
+  text-transform: uppercase;
+  font-size: 0.85rem;
+  letter-spacing: 0.05em;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.details-card summary::marker,
+.info-card summary::marker {
+  color: #ffb0ff;
+}
+
+.details-content {
+  display: grid;
+  gap: 1.25rem;
+  margin-top: 1rem;
+}
+
+.helper-list {
+  margin: 0.75rem 0 0;
+  padding-left: 1.25rem;
+  display: grid;
+  gap: 0.5rem;
+  font-size: 0.9rem;
+  opacity: 0.85;
+}
+
+.helper-list--ordered {
+  list-style: decimal;
+  padding-left: 1.5rem;
+}
+
+.helper-list code {
+  font-family: 'Fira Code', 'SFMono-Regular', Consolas, monospace;
+  background: rgba(255, 255, 255, 0.08);
+  padding: 0.2rem 0.35rem;
+  border-radius: 4px;
+}
+
+.form-hint {
+  margin: 0 0 1rem;
+  font-size: 0.9rem;
+  opacity: 0.75;
+}
+
+.form-hint a {
+  color: #7cf7ff;
+}
+
+.chat-console {
+  background: rgba(10, 12, 26, 0.85);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 16px;
+  padding: 1.25rem;
+  min-height: 280px;
+  max-height: 520px;
+  overflow-y: auto;
+  font-family: 'Fira Code', 'SFMono-Regular', Consolas, monospace;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.console-empty-state {
+  opacity: 0.6;
+  font-size: 0.9rem;
+}
+
+.console-line {
+  border-left: 3px solid rgba(255, 255, 255, 0.12);
+  padding: 0.5rem 0 0.5rem 1rem;
+  background: rgba(255, 255, 255, 0.03);
+  border-radius: 8px;
+  display: grid;
+  gap: 0.3rem;
+}
+
+.console-line__meta {
+  font-size: 0.8rem;
+  opacity: 0.75;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.console-line__message {
+  white-space: pre-wrap;
+  font-size: 0.95rem;
+  line-height: 1.4;
+}
+
+.console-line--incoming {
+  border-left-color: #ff6ec7;
+}
+
+.console-line--outgoing {
+  border-left-color: #7cf7ff;
+}
+
+.console-line--system {
+  border-left-color: #ffd27c;
+}
+
+.chat-console-actions {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.status-chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.35rem 0.85rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  border: 1px solid transparent;
+  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+
+.status-chip--connected {
+  background: rgba(124, 247, 255, 0.2);
+  color: #7cf7ff;
+  border-color: rgba(124, 247, 255, 0.35);
+}
+
+.status-chip--reconnecting {
+  background: rgba(255, 210, 124, 0.15);
+  color: #ffd27c;
+  border-color: rgba(255, 210, 124, 0.35);
+}
+
+.status-chip--disconnected {
+  background: rgba(255, 138, 183, 0.15);
+  color: #ff8ab7;
+  border-color: rgba(255, 138, 183, 0.35);
+}
+
+.chat-hints .helper-list {
+  margin-top: 0.5rem;
+}
+
 #command-table {
   width: 100%;
   border-collapse: collapse;
@@ -101,7 +432,21 @@ button:hover {
     padding: 1rem;
   }
 
+  .page-nav {
+    justify-content: center;
+  }
+
   section {
     padding: 1rem;
+  }
+
+  .chat-log-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .section-header {
+    flex-direction: column;
+    align-items: flex-start;
   }
 }


### PR DESCRIPTION
## Summary
- implement server-sent events chat stream and REST endpoints to log, stream, and clear messages
- rebuild the chat console to consume the live stream, send messages with the configured identity, and offer simulation tooling
- refresh the configuration UI with documentation links, inline status feedback, and an OAuth token shortcut, alongside updated styling support

## Testing
- node -e "const { server } = require('./src/server'); setTimeout(() => server.close(), 10);"

------
https://chatgpt.com/codex/tasks/task_e_68dfdb1d4900832fa88ffac58551e30a