### PR TITLE
Add Twitch token generator shortcut

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -54,13 +54,19 @@
                   type="password"
                   placeholder="oauth:xxxxxxxxxxxxxxxx"
                 />
-                <button type="button" class="secondary-button" id="twitch-oauth-button">
-                  OAuth Token erzeugen
-                </button>
+                <div class="button-row">
+                  <button type="button" class="secondary-button" id="twitch-oauth-button">
+                    Offizielles OAuth Tool öffnen
+                  </button>
+                  <button type="button" class="secondary-button" id="twitch-token-generator-button">
+                    Twitch Token Generator testen
+                  </button>
+                </div>
               </div>
               <p class="field-hint">
-                Der Button öffnet das offizielle <strong>Twitch Chat OAuth Tool</strong> (twitchapps.com/tmi).
-                Der Token benötigt mindestens die Scopes <code>chat:read</code> und <code>chat:edit</code>.
+                Du kannst wahlweise das offizielle <strong>Twitch Chat OAuth Tool</strong> (twitchapps.com/tmi) nutzen
+                oder testweise den <strong>Twitch Token Generator</strong> (twitchtokengenerator.com) aufrufen. Der
+                Token benötigt mindestens die Scopes <code>chat:read</code> und <code>chat:edit</code>.
               </p>
             </div>
 
@@ -104,7 +110,10 @@
         <details class="info-card">
           <summary>Schnellstart &amp; hilfreiche Links</summary>
           <ol class="helper-list helper-list--ordered">
-            <li>Logge dich mit deinem Bot-Konto ein und generiere den OAuth Token über den Button oben.</li>
+            <li>
+              Logge dich mit deinem Bot-Konto ein und generiere den OAuth Token über eines der Tools oben (offiziell
+              oder Twitch Token Generator zum Testen).
+            </li>
             <li>Trage den Namen des Kanals ein, in dem der Bot aktiv sein soll, und speichere die Einstellungen.</li>
             <li>Nutze „Verbindung testen“, um zu prüfen, ob die gespeicherten Daten gültig wirken.</li>
           </ol>

--- a/public/main.js
+++ b/public/main.js
@@ -98,8 +98,13 @@ async function init() {
   });
 
   document.getElementById('twitch-oauth-button').addEventListener('click', () => {
-    setStatus(twitchStatus, 'Öffne Twitch OAuth Tool …', 'info');
+    setStatus(twitchStatus, 'Öffne offizielles Twitch OAuth Tool …', 'info');
     window.open('https://twitchapps.com/tmi/', '_blank', 'noopener');
+  });
+
+  document.getElementById('twitch-token-generator-button').addEventListener('click', () => {
+    setStatus(twitchStatus, 'Öffne Twitch Token Generator zum Testen …', 'info');
+    window.open('https://twitchtokengenerator.com', '_blank', 'noopener');
   });
 
   document.getElementById('twitch-form').addEventListener('submit', async event => {

--- a/public/styles.css
+++ b/public/styles.css
@@ -144,6 +144,12 @@ form {
   gap: 0.75rem;
 }
 
+.button-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
 .form-row {
   display: grid;
   gap: 0.5rem;


### PR DESCRIPTION
## Summary
- add a secondary shortcut in the Twitch OAuth section for the Twitch Token Generator
- update the hint text and quickstart instructions to mention both token tools
- tweak styling and status messaging to support the new button

## Testing
- npm start

------
https://chatgpt.com/codex/tasks/task_e_68dfe3581f90832fabbb7f1a6ac7293f