### PR TITLE
Integrate Twitch chat relay

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,5 +14,8 @@
   ],
   "author": "",
   "license": "ISC",
-  "type": "commonjs"
+  "type": "commonjs",
+  "dependencies": {
+    "tmi.js": "^1.8.5"
+  }
 }

--- a/src/twitchChatManager.js
+++ b/src/twitchChatManager.js
@@ -1,0 +1,164 @@
+const EventEmitter = require('events');
+let tmi;
+
+try {
+  tmi = require('tmi.js');
+} catch (error) {
+  tmi = null;
+}
+
+class TwitchChatManager extends EventEmitter {
+  constructor({ loadConfig, onChatMessage, onStatus }) {
+    super();
+    this.loadConfig = loadConfig;
+    this.onChatMessage = onChatMessage;
+    this.onStatus = onStatus;
+    this.client = null;
+    this.connected = false;
+    this.activeConfig = null;
+
+    this.updateConfig(this.loadConfig().twitch || {});
+  }
+
+  hasValidConfig(config) {
+    if (!config) {
+      return false;
+    }
+    return Boolean(
+      config.username &&
+        config.oauthToken &&
+        config.channel &&
+        typeof config.username === 'string' &&
+        typeof config.oauthToken === 'string' &&
+        typeof config.channel === 'string'
+    );
+  }
+
+  sanitizeChannel(channel) {
+    if (!channel) {
+      return null;
+    }
+    return channel.startsWith('#') ? channel : `#${channel}`;
+  }
+
+  sanitizeToken(token) {
+    if (!token) {
+      return null;
+    }
+    return token.startsWith('oauth:') ? token : `oauth:${token}`;
+  }
+
+  configsEqual(a = {}, b = {}) {
+    return (
+      a.username === b.username &&
+      a.oauthToken === b.oauthToken &&
+      a.channel === b.channel
+    );
+  }
+
+  disconnect(reason) {
+    this.connected = false;
+    if (this.client) {
+      try {
+        this.client.removeAllListeners();
+        const disconnectPromise = this.client.disconnect();
+        if (disconnectPromise && typeof disconnectPromise.catch === 'function') {
+          disconnectPromise.catch(() => {});
+        }
+      } catch (error) {
+        // ignore disconnect errors
+      }
+      this.client = null;
+    }
+    if (reason) {
+      this.emitStatus(reason);
+    }
+  }
+
+  emitStatus(message) {
+    if (typeof this.onStatus === 'function' && message) {
+      this.onStatus(message);
+    }
+  }
+
+  updateConfig(nextConfig) {
+    const twitchConfig = nextConfig || {};
+    if (!tmi) {
+      this.emitStatus('tmi.js konnte nicht geladen werden. Twitch-Chat ist deaktiviert.');
+      return;
+    }
+
+    if (!this.hasValidConfig(twitchConfig)) {
+      this.disconnect('Twitch-Chat Konfiguration unvollständig.');
+      this.activeConfig = null;
+      return;
+    }
+
+    if (this.activeConfig && this.configsEqual(this.activeConfig, twitchConfig)) {
+      return;
+    }
+
+    this.activeConfig = { ...twitchConfig };
+    this.connect();
+  }
+
+  connect() {
+    if (!tmi || !this.activeConfig) {
+      return;
+    }
+
+    this.disconnect();
+
+    const channel = this.sanitizeChannel(this.activeConfig.channel);
+    const token = this.sanitizeToken(this.activeConfig.oauthToken);
+
+    this.client = new tmi.Client({
+      options: { debug: false },
+      identity: {
+        username: this.activeConfig.username,
+        password: token
+      },
+      channels: [channel],
+      connection: { reconnect: true, secure: true }
+    });
+
+    this.client.on('connected', () => {
+      this.connected = true;
+      this.emitStatus(`Mit Twitch-Chat ${channel} verbunden.`);
+    });
+
+    this.client.on('disconnected', reason => {
+      this.connected = false;
+      this.emitStatus(`Twitch-Chat getrennt: ${reason || 'unbekannt'}.`);
+    });
+
+    this.client.on('message', (chan, tags, message, self) => {
+      if (self) {
+        return;
+      }
+      if (typeof this.onChatMessage === 'function') {
+        const username = tags['display-name'] || tags.username || 'Unbekannt';
+        this.onChatMessage({
+          channel: chan,
+          username,
+          message
+        });
+      }
+    });
+
+    this.client.connect().catch(error => {
+      this.connected = false;
+      this.emitStatus(`Twitch-Chat Verbindung fehlgeschlagen: ${error.message}`);
+    });
+  }
+
+  async sendMessage(message) {
+    if (!this.client || !this.connected) {
+      throw new Error('Keine aktive Twitch-Chat Verbindung.');
+    }
+    const channel = this.sanitizeChannel(this.activeConfig.channel);
+    await this.client.say(channel, message);
+  }
+}
+
+module.exports = { TwitchChatManager };


### PR DESCRIPTION
## Summary
- add a TwitchChatManager that connects to the configured Twitch channel and emits incoming chat messages to the SSE log
- normalize chat entries on the backend so that Twitch activity and status updates are recorded consistently
- forward outgoing chat messages from the UI to the live Twitch chat when the transport is set to Twitch and refresh the connection after configuration changes

## Testing
- node src/server.js

------
https://chatgpt.com/codex/tasks/task_e_68dfe6d0763c832f8e75fba4de8639d6