### PR TITLE
Handle offline Twitch chat gracefully

### DIFF
--- a/public/chat-log.js
+++ b/public/chat-log.js
@@ -16,6 +16,19 @@ let currentIdentity = '';
 let eventSource = null;
 let connectionState = 'disconnected';
 
+function toneForDeliveryStatus(status) {
+  switch (status) {
+    case 'sent':
+      return 'success';
+    case 'queued':
+      return 'warning';
+    case 'stored':
+      return 'info';
+    default:
+      return 'info';
+  }
+}
+
 const timeFormatter = new Intl.DateTimeFormat('de-DE', {
   hour: '2-digit',
   minute: '2-digit',
@@ -206,14 +219,15 @@ sendForm.addEventListener('submit', async event => {
   try {
     sendButton.disabled = true;
     setStatus('Sende Nachricht …', 'info');
-    await postChatMessage({
+    const result = await postChatMessage({
       username: currentIdentity,
       message,
       direction: 'outgoing',
       transport: 'twitch'
     });
     messageInput.value = '';
-    setStatus('Nachricht an den Chat übermittelt (lokales Protokoll).', 'success');
+    const note = result?.note || 'Nachricht an den Chat übermittelt (lokales Protokoll).';
+    setStatus(note, toneForDeliveryStatus(result?.status));
   } catch (error) {
     console.error('Failed to send chat message', error);
     setStatus(`Fehler beim Senden: ${error.message}`, 'error');
@@ -257,13 +271,14 @@ previewButton.addEventListener('click', async () => {
 
   try {
     setStatus('Füge Testeintrag hinzu …', 'info');
-    await postChatMessage({
+    const result = await postChatMessage({
       username,
       message,
       direction: 'incoming',
       transport: 'simulation'
     });
-    setStatus('Testeintrag erstellt.', 'success');
+    const note = result?.note || 'Testeintrag erstellt.';
+    setStatus(note, toneForDeliveryStatus(result?.status));
   } catch (error) {
     console.error('Failed to create preview entry', error);
     setStatus(`Testeintrag fehlgeschlagen: ${error.message}`, 'error');

--- a/public/main.js
+++ b/public/main.js
@@ -126,10 +126,19 @@ async function init() {
       const result = await testConnection('/api/test/twitch');
       const timeLabel = new Date(result.timestamp).toLocaleTimeString();
       const details = result.message ? ` – ${result.message}` : '';
+      const statusLabel = (result.status || 'unbekannt').toUpperCase();
+      const toneMap = {
+        ok: 'success',
+        connected: 'success',
+        offline: 'warning',
+        unconfigured: 'warning',
+        error: 'error'
+      };
+      const tone = toneMap[result.status] || 'info';
       setStatus(
         twitchStatus,
-        `${result.service}: ${result.status.toUpperCase()} (${timeLabel})${details}`,
-        'success'
+        `${result.service}: ${statusLabel} (${timeLabel})${details}`,
+        tone
       );
     } catch (error) {
       setStatus(twitchStatus, error.message, 'error');

--- a/src/server.js
+++ b/src/server.js
@@ -257,29 +257,33 @@ const server = http.createServer(async (req, res) => {
 
       const entry = createChatEntry({ username, message, direction, transport });
 
+      let status = 'stored';
+      let note = 'Chatnachricht wurde gespeichert.';
+      let followUpEntry = null;
+
       if (entry.direction === 'outgoing' && entry.transport === 'twitch') {
         try {
           await twitchChatManager.sendMessage(entry.message);
+          status = 'sent';
+          note = 'Chatnachricht wurde an Twitch übermittelt.';
         } catch (error) {
           console.error('Failed to send Twitch chat message', error);
-          sendJson(res, 502, {
-            message: 'Twitch-Chat Nachricht konnte nicht gesendet werden.',
-            error: error.message
+          status = 'queued';
+          note = `Twitch Versand fehlgeschlagen (${error.message}). Nachricht lokal gespeichert.`;
+          followUpEntry = createChatEntry({
+            username: 'System',
+            message: `Twitch Versand fehlgeschlagen: ${error.message}.`,
+            direction: 'system',
+            transport: 'twitch'
           });
-          return;
         }
       }
 
       pushChatEntry(entry);
 
-      const status =
-        entry.direction === 'outgoing' && entry.transport === 'twitch'
-          ? 'sent'
-          : 'stored';
-      const note =
-        status === 'sent'
-          ? 'Chatnachricht wurde an Twitch übermittelt.'
-          : 'Chatnachricht wurde gespeichert.';
+      if (followUpEntry) {
+        pushChatEntry(followUpEntry);
+      }
 
       sendJson(res, 200, {
         status,
@@ -326,15 +330,19 @@ const server = http.createServer(async (req, res) => {
         sendJson(res, 200, {
           ...responsePayload,
           service: 'twitch',
-          status: 'ok',
+          status: result.status || 'ok',
           message: result.message
         });
       } catch (error) {
-        sendJson(res, 503, {
+        const errorMessage = error?.message || 'Unbekannter Fehler';
+        const status = /konfiguration/i.test(errorMessage)
+          ? 'unconfigured'
+          : 'offline';
+        sendJson(res, 200, {
           ...responsePayload,
           service: 'twitch',
-          status: 'error',
-          message: error.message
+          status,
+          message: errorMessage
         });
       }
       return;


### PR DESCRIPTION
## Summary
- keep chat message requests successful even when Twitch delivery fails and log a system warning
- return richer status codes for the Twitch connectivity probe instead of HTTP errors
- update the chat log and configuration UI to surface the new delivery and connectivity statuses

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfed7f9264832f87c7d7ff1ab6d9c9